### PR TITLE
feat: inclusão de documentação swagger-ui

### DIFF
--- a/products-ms/build.gradle.kts
+++ b/products-ms/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-cache")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.7.0")
     testImplementation("org.junit.jupiter:junit-jupiter-engine:5.7.0")

--- a/products-ms/src/main/kotlin/puc/application/controllers/ProductController.kt
+++ b/products-ms/src/main/kotlin/puc/application/controllers/ProductController.kt
@@ -1,5 +1,6 @@
 package puc.application.controllers
 
+import io.swagger.v3.oas.annotations.Operation
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.util.UriComponentsBuilder
@@ -19,14 +20,13 @@ class ProductController(
 ) {
 
     @GetMapping
+    @Operation(summary = "List all products", description = "Returns a list of all available products")
     fun getAllProducts(
         @RequestParam(required = false) name: String?,
         @RequestParam(required = false) category: String?,
         @RequestParam(required = false) page: Int?,
-        @RequestParam(required = false) pageSize: Int?,
-
-        ): ResponseEntity<PaginatedResponseDTO<Product>> {
-
+        @RequestParam(required = false) pageSize: Int?
+    ): ResponseEntity<PaginatedResponseDTO<Product>> {
         val param = FilterProductParamsDTO(
             name = name,
             category = category,
@@ -40,14 +40,20 @@ class ProductController(
     }
 
     @GetMapping("/{id}")
-    fun getById(@PathVariable id: String): ResponseEntity<Any> {
+    @Operation(summary = "Search for product by ID", description = "Returns a product by its ID")
+    fun getById(
+        @PathVariable id: String
+    ): ResponseEntity<Any> {
         val product = productService.findById(id)
         return ResponseEntity.ok(mapOf("product" to product))
     }
 
     @PostMapping
-    fun postProduct(@RequestBody productDTO: ProductDTO,
-                    uriComponentsBuilder: UriComponentsBuilder): ResponseEntity<Any>{
+    @Operation(summary = "Create a new product", description = "Creates a new product and returns the created product")
+    fun postProduct(
+        @RequestBody productDTO: ProductDTO,
+        uriComponentsBuilder: UriComponentsBuilder
+    ): ResponseEntity<Any>{
         val result =  productService.save(ProductMapper.dtoToDomain(productDTO))
         val location = uriComponentsBuilder
             .path("/products/{id}")
@@ -59,9 +65,11 @@ class ProductController(
     }
 
     @PutMapping("/{id}")
+    @Operation(summary = "Update an existing product", description = "Updates a product by its ID and returns the updated product")
     fun putProduct( @PathVariable id: String,
                     @RequestBody productDTO: ProductDTO,
-                    uriComponentsBuilder: UriComponentsBuilder): ResponseEntity<Any>{
+                    uriComponentsBuilder: UriComponentsBuilder
+    ): ResponseEntity<Any>{
         val result =  productService.update(ProductMapper.dtoToDomain(productDTO), id)
         val location = uriComponentsBuilder
             .path("/products/{id}")
@@ -71,7 +79,10 @@ class ProductController(
     }
 
     @DeleteMapping("/{idProduct}")
-    fun deleteProduct(@PathVariable idProduct:String) : ResponseEntity<Any>{
+    @Operation(summary = "Delete a product", description = "Remove a product by its ID")
+    fun deleteProduct(
+        @PathVariable idProduct:String
+    ) : ResponseEntity<Any>{
         productService.delete(idProduct)
         productEventPublisher.publishProductDeletedEvent(idProduct)
         return ResponseEntity.ok(mapOf("message" to "Product deleted successfully"))

--- a/products-ms/src/main/kotlin/puc/infrastructure/configs/SwaggerConfig.kt
+++ b/products-ms/src/main/kotlin/puc/infrastructure/configs/SwaggerConfig.kt
@@ -1,0 +1,21 @@
+﻿package puc.infrastructure.configs
+
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.info.Info
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class SwaggerConfig {
+
+    @Bean
+    fun customOpenAPI(): OpenAPI {
+        return OpenAPI()
+            .info(
+                Info()
+                    .title("products-ms-api")
+                    .version("1.0")
+                    .description("Products API Documentation")
+            )
+    }
+}


### PR DESCRIPTION
## Comportamento adicionado

1. Inclusão de documentação Swagger na api de produtos;
2. Acesso em http://localhost:8080/swagger-ui/index.html 
3. Utilizada dependencia _org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0_

## Evidencias:
![image](https://github.com/user-attachments/assets/41510c29-165b-4d91-8963-fb188643e614)
